### PR TITLE
Split total_energy_bought into total_energy_bought and grid_frequency for deye hybrid

### DIFF
--- a/src/deye_sensors_deye_hybrid.py
+++ b/src/deye_sensors_deye_hybrid.py
@@ -190,7 +190,17 @@ deye_hybrid_grid_76 = SingleRegisterSensor(
     groups=["deye_hybrid"],
 )
 
-deye_hybrid_grid_78 = DoubleRegisterSensor(
+deye_hybrid_grid_77 = SingleRegisterSensor(
+    "Daily Energy Sold",
+    77,
+    0.1,
+    mqtt_topic_suffix="ac/daily_energy_sold",
+    unit="kWh",
+    signed=False,
+    groups=["deye_hybrid"],
+)
+
+deye_hybrid_grid_78 = SingleRegisterSensor(
     "Total Energy Bought",
     78,
     0.1,
@@ -200,12 +210,12 @@ deye_hybrid_grid_78 = DoubleRegisterSensor(
     groups=["deye_hybrid"],
 )
 
-deye_hybrid_grid_77 = SingleRegisterSensor(
-    "Daily Energy Sold",
-    77,
-    0.1,
-    mqtt_topic_suffix="ac/daily_energy_sold",
-    unit="kWh",
+deye_hybrid_grid_79 = SingleRegisterSensor(
+    "Grid Frequecy",
+    79,
+    0.01,
+    mqtt_topic_suffix="ac/grid_frequency",
+    unit="Hz",
     signed=False,
     groups=["deye_hybrid"],
 )
@@ -660,8 +670,9 @@ deye_hybrid_sensors = [
     deye_hybrid_grid_170,
     deye_hybrid_grid_171,
     deye_hybrid_grid_76,
-    deye_hybrid_grid_78,
     deye_hybrid_grid_77,
+    deye_hybrid_grid_78,
+    deye_hybrid_grid_79,
     deye_hybrid_grid_81,
     deye_hybrid_inverter_175,
     deye_hybrid_inverter_164,


### PR DESCRIPTION
My testing shows that the original number for total_energy_bought in fact it was very out. It did not match what was in MQTT when compared to Solarman, when i split them, register 78's value now matches solarman and register 79's value matches the Grid Frequency, when the grid is disconnected it (register 79) goes to 0.

I can confirm based on the below images and comparing isolating the grid that 79 is the grid frequency on my inverter. I do see other projects treat the total_energy_bought as a 4byte register instead of 2bytes, so this could be an error in copying other work or registers are fickle between models.

<img width="377" height="66" alt="image" src="https://github.com/user-attachments/assets/abfaa180-48cb-4b48-8a8a-3e2bc7549746" />
<img width="473" height="96" alt="image" src="https://github.com/user-attachments/assets/0f8df235-8c2b-49fb-b48f-34a3212b4262" />

70 tests passing and 4 warnings - i didn't add a test as there are no tests for definition files.

Let me know if you require any other testing/evidence